### PR TITLE
Make PromptWeekInReview logic correct

### DIFF
--- a/src/pages/WeekInReview.css
+++ b/src/pages/WeekInReview.css
@@ -4,6 +4,7 @@
 
 .question {
     font-size: 19px;
+    max-width: 600px;
 }
 
 .screener-button {
@@ -12,6 +13,7 @@
 
 .screener-container {
     height: 100%;
+    max-width: 800px;
 }
 
 .screener-container div:first-of-type {

--- a/src/screeners/dass.tsx
+++ b/src/screeners/dass.tsx
@@ -167,7 +167,7 @@ export default function DASS(): Screener {
                 </p>
                 { problemFlag && <p>We understand your results today might be distressing or scary. If you can, take a minute to consider 
                     why your results are the way they are. Is there anything you can do to help move them in a better direction? 
-                    If your results have been consistently severe over time, we recommend reaching out to others for 
+                    And if your results have been consistently severe over time, we recommend reaching out to others for 
                     support. Check out the help resources in the main menu for more detailed guidance.
                 </p> }
             </>;


### PR DESCRIPTION
Previously, if a user had their first WIR on a Thursday, they'd never get a WIR again! So obviously, there were some issues. This new model uses a stable "trigger date", which is calculated either using first log or last week in review. There is no way to not get a WIR, and except for the first, they're always triggered after Friday at noon.

- [x] Code review